### PR TITLE
chore: use inputs context instead of github.event.inputs for reusable…

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -31,22 +31,22 @@ on:
 
 jobs:
   build_and_publish_frontend:
-    name: Build and publish frontend image for ${{ github.event.inputs.environment }}
-    environment: ${{ github.event.inputs.environment }}
+    name: Build and publish frontend image for ${{ inputs.environment }}
+    environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     env:
       DOCKER_LOGIN: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       DOCKER_REPO: ${{ secrets.DOCKER_REPO || 'olakego' }}
       DOCKER_REPO_WORKER: ${{ secrets.DOCKER_REPO_WORKER || 'olakego' }}
-      ENVIRONMENT: ${{ github.event.inputs.environment }}
-      VERSION: ${{ github.event.inputs.version }}
+      ENVIRONMENT: ${{ inputs.environment }}
+      VERSION: ${{ inputs.version }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.environment == 'master' && 'master' || (github.event.inputs.environment == 'staging' && 'staging' || github.event.inputs.environment == 'dev' && 'ci/workerReleaseIssues' || 'develop') }}
+          ref: ${{ inputs.environment == 'master' && 'master' || (inputs.environment == 'staging' && 'staging' || inputs.environment == 'dev' && 'ci/workerReleaseIssues' || 'develop') }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/draft-release-and-changelog.yml
+++ b/.github/workflows/draft-release-and-changelog.yml
@@ -29,7 +29,7 @@ jobs:
         id: generate-next-version
         run: |
           if [ -z "$LATEST_TAG" ]; then
-            next_version="v0.1.0"
+            next_version="v0.0.5"
           else
             # Remove 'v' prefix and split version into array
             version=${LATEST_TAG#v}


### PR DESCRIPTION
… workflow compatibility

Replace all references to github.event.inputs.environment and github.event.inputs.version with inputs.environment and inputs.version to ensure the workflow functions correctly when called as a reusable workflow via workflow_call trigger.

This change ensures the build-and-release.yml workflow can be successfully called from release-approval.yml without build failures due to empty environment variables.

References:
- https://docs.github.com/en/actions/reference/accessing-contextual-information-about-workflow-runs#example-usage-of-the-inputs-context-in-a-reusable-workflow
- https://docs.github.com/en/actions/reference/events-that-trigger-workflows#providing-inputs

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
